### PR TITLE
use terraform-in-action instead of scottwinkler

### DIFF
--- a/modules/autoscaling/main.tf
+++ b/modules/autoscaling/main.tf
@@ -1,6 +1,6 @@
 #create instance and autoscaling group and lb listeners
 module "iam_instance_profile" {
-  source  = "scottwinkler/iip/aws"
+  source  = "terraform-in-action/iip/aws"
   actions = ["logs:*"]
 }
 

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -43,7 +43,7 @@ module "vpc" {
 }
 
 module "lb_sg" {
-  source = "scottwinkler/sg/aws"
+  source = "terraform-in-action/sg/aws"
   vpc_id = module.vpc.vpc_id
   ingress_rules = [{
     port        = 80
@@ -52,7 +52,7 @@ module "lb_sg" {
 }
 
 module "webserver_sg" {
-  source = "scottwinkler/sg/aws"
+  source = "terraform-in-action/sg/aws"
   vpc_id = module.vpc.vpc_id
   ingress_rules = [
     {


### PR DESCRIPTION
I received this error when running `terraform init` on listing 9.1:

```
Dustins-MacBook-Pro:listing9.1 dustinalandzes$ terraform init
Initializing modules...
Downloading terraform-in-action/aws/bluegreen 0.1.2 for base...
- base in .terraform/modules/base/modules/base
Downloading scottwinkler/sg/aws 0.0.5 for base.lb_sg...
Downloading terraform-aws-modules/vpc/aws 2.17.0 for base.vpc...
- base.vpc in .terraform/modules/base.vpc
Downloading scottwinkler/sg/aws 0.0.5 for base.webserver_sg...
Downloading terraform-in-action/aws/bluegreen 0.1.2 for blue...
- blue in .terraform/modules/blue/modules/autoscaling
Downloading scottwinkler/iip/aws 0.1.0 for blue.iam_instance_profile...
Downloading terraform-in-action/aws/bluegreen 0.1.2 for green...
- green in .terraform/modules/green/modules/autoscaling
Downloading scottwinkler/iip/aws 0.1.0 for green.iam_instance_profile...
╷
│ Error: Failed to download module
│ 
│ Could not download module "lb_sg" (.terraform/modules/base/modules/base/main.tf:45) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.lb_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "webserver_sg" (.terraform/modules/base/modules/base/main.tf:54) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.webserver_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "iam_instance_profile" (.terraform/modules/blue/modules/autoscaling/main.tf:2) source code from "git::https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0': /usr/bin/git exited with 128: Cloning into '.terraform/modules/blue.iam_instance_profile'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-iip/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "iam_instance_profile" (.terraform/modules/green/modules/autoscaling/main.tf:2) source code from "git::https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0': /usr/bin/git exited with 128: Cloning into '.terraform/modules/green.iam_instance_profile'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-iip/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "lb_sg" (.terraform/modules/base/modules/base/main.tf:45) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.lb_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "lb_sg" (.terraform/modules/base/modules/base/main.tf:45) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.lb_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "lb_sg" (.terraform/modules/base/modules/base/main.tf:45) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.lb_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "webserver_sg" (.terraform/modules/base/modules/base/main.tf:54) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.webserver_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "lb_sg" (.terraform/modules/base/modules/base/main.tf:45) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.lb_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "webserver_sg" (.terraform/modules/base/modules/base/main.tf:54) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.webserver_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "lb_sg" (.terraform/modules/base/modules/base/main.tf:45) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.lb_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "webserver_sg" (.terraform/modules/base/modules/base/main.tf:54) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.webserver_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "iam_instance_profile" (.terraform/modules/blue/modules/autoscaling/main.tf:2) source code from "git::https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0': /usr/bin/git exited with 128: Cloning into '.terraform/modules/blue.iam_instance_profile'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-iip/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "lb_sg" (.terraform/modules/base/modules/base/main.tf:45) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.lb_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "webserver_sg" (.terraform/modules/base/modules/base/main.tf:54) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.webserver_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "iam_instance_profile" (.terraform/modules/blue/modules/autoscaling/main.tf:2) source code from "git::https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0': /usr/bin/git exited with 128: Cloning into '.terraform/modules/blue.iam_instance_profile'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-iip/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "lb_sg" (.terraform/modules/base/modules/base/main.tf:45) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.lb_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "webserver_sg" (.terraform/modules/base/modules/base/main.tf:54) source code from "git::https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-sg?ref=v0.0.5': /usr/bin/git exited with 128: Cloning into '.terraform/modules/base.webserver_sg'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-sg/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "iam_instance_profile" (.terraform/modules/blue/modules/autoscaling/main.tf:2) source code from "git::https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0': /usr/bin/git exited with 128: Cloning into '.terraform/modules/blue.iam_instance_profile'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-iip/' not found
│ .
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "iam_instance_profile" (.terraform/modules/green/modules/autoscaling/main.tf:2) source code from "git::https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0": error downloading
│ 'https://github.com/scottwinkler/terraform-aws-iip?ref=v0.1.0': /usr/bin/git exited with 128: Cloning into '.terraform/modules/green.iam_instance_profile'...
│ remote: Repository not found.
│ fatal: repository 'https://github.com/scottwinkler/terraform-aws-iip/' not found
│ .
╵
```

You can test this change by replacing terraform-in-action with DustinAlandzes on listing 9.1

here's the output after the change:
```
Dustins-MacBook-Pro:listing9.1 dustinalandzes$ terraform init
Initializing modules...
Downloading DustinAlandzes/aws/bluegreen 0.1.4 for base...
- base in .terraform/modules/base/modules/base
Downloading terraform-in-action/sg/aws 0.1.0 for base.lb_sg...
- base.lb_sg in .terraform/modules/base.lb_sg
Downloading terraform-aws-modules/vpc/aws 2.17.0 for base.vpc...
- base.vpc in .terraform/modules/base.vpc
Downloading terraform-in-action/sg/aws 0.1.0 for base.webserver_sg...
- base.webserver_sg in .terraform/modules/base.webserver_sg
Downloading DustinAlandzes/aws/bluegreen 0.1.4 for blue...
- blue in .terraform/modules/blue/modules/autoscaling
Downloading terraform-in-action/iip/aws 0.1.0 for blue.iam_instance_profile...
- blue.iam_instance_profile in .terraform/modules/blue.iam_instance_profile
Downloading DustinAlandzes/aws/bluegreen 0.1.4 for green...
- green in .terraform/modules/green/modules/autoscaling
Downloading terraform-in-action/iip/aws 0.1.0 for green.iam_instance_profile...
- green.iam_instance_profile in .terraform/modules/green.iam_instance_profile

Initializing the backend...

Initializing provider plugins...
- Finding latest version of hashicorp/aws...
- Finding latest version of hashicorp/random...
- Installing hashicorp/aws v3.63.0...
- Installed hashicorp/aws v3.63.0 (signed by HashiCorp)
- Installing hashicorp/random v3.1.0...
- Installed hashicorp/random v3.1.0 (signed by HashiCorp)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```